### PR TITLE
[12.0][FIX] hr_timesheet_report_hide_responsible: wrong i18n files

### DIFF
--- a/hr_timesheet_report_hide_responsible/__manifest__.py
+++ b/hr_timesheet_report_hide_responsible/__manifest__.py
@@ -6,7 +6,7 @@
         Adds a report that hides the responsible
         users column if there is only one.
     """,
-    "version": "12.0.1.0.0",
+    "version": "12.0.1.0.1",
     "license": "LGPL-3",
     "category": "Human Resources",
     "author": "Solvos",

--- a/hr_timesheet_report_hide_responsible/i18n/es.po
+++ b/hr_timesheet_report_hide_responsible/i18n/es.po
@@ -18,6 +18,6 @@ msgstr ""
 "Language: es_ES\n"
 
 #. module: hr_timesheet_report_hide_responsible
-#: model_terms:ir.ui.view,arch_db:hr_timesheet_report_hide_responsible.report_timesheet_hide_responsible_users
+#: model_terms:ir.ui.view,arch_db:hr_timesheet_report_hide_responsible.report_timesheet_hide_responsible
 msgid "Responsible:"
 msgstr "Responsable:"

--- a/hr_timesheet_report_hide_responsible/i18n/hr_timesheet_report_hide_responsible.pot
+++ b/hr_timesheet_report_hide_responsible/i18n/hr_timesheet_report_hide_responsible.pot
@@ -16,7 +16,7 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: hr_timesheet_report_hide_responsible
-#: model_terms:ir.ui.view,arch_db:hr_timesheet_report_hide_responsible.report_timesheet_hide_responsible_users
+#: model_terms:ir.ui.view,arch_db:hr_timesheet_report_hide_responsible.report_timesheet_hide_responsible
 msgid "Responsible:"
 msgstr ""
 


### PR DESCRIPTION
Translations weren't loaded due to a missing refactoring changing addon name