### PR TITLE
[17.0][UPD] hr_timesheet_day_week: make it uninstallable

### DIFF
--- a/hr_timesheet_day_week/__manifest__.py
+++ b/hr_timesheet_day_week/__manifest__.py
@@ -13,5 +13,5 @@
     "author": "Solvos Consultoría Informática",
     "website": "https://github.com/solvosci/slv-timesheet",
     "license": "LGPL-3",
-    "installable": True,
+    "installable": False,
 }


### PR DESCRIPTION
This addon is intenteded to be replaced by OCA's version, recently donated.